### PR TITLE
Oil pier not working in New world

### DIFF
--- a/[Gameplay] Oil Pier/data/config/export/main/asset/assets.xml
+++ b/[Gameplay] Oil Pier/data/config/export/main/asset/assets.xml
@@ -615,7 +615,7 @@
     </ModOp>
     <!-- Oil Pier -->
     <!-- harbour tier02 (behind oil depot) -->
-    <ModOp Type="addNextSibling" GUID='501008' Path="Values/ConstructionCategory/BuildingList/Item[Building = '101330']">
+    <ModOp Type="addNextSibling" GUID='501008' Path="Values/ConstructionCategory/BuildingList/Item[Building = '632']">
         <Item>
             <Building>8855081</Building>
         </Item>


### PR DESCRIPTION
Edited building id to the new one, the error in the log was bugging me, and the pier didnt work in new world. :P